### PR TITLE
Fix AgriRequirement constructor typo

### DIFF
--- a/src/main/java/com/agricraft/agricore/plant/AgriRequirement.java
+++ b/src/main/java/com/agricraft/agricore/plant/AgriRequirement.java
@@ -30,8 +30,8 @@ public class AgriRequirement {
     public AgriRequirement(List<String> soils, List<AgriCondition> conditions, int min_light, int max_light) {
         this.soils = new ArrayList<>(soils);
         this.conditions = conditions;
-        this.min_light = 10;
-        this.max_light = 16;
+        this.min_light = min_light;
+        this.max_light = max_light;
     }
 
     public int getMinLight() {


### PR DESCRIPTION
It will now set min_light and max_light to the given input, instead of
being hardcoded to fixed values like the zero parameter constructor.