### PR TITLE
Make AgriCondition#toStack use the amount value

### DIFF
--- a/src/main/java/com/agricraft/agricore/plant/AgriCondition.java
+++ b/src/main/java/com/agricraft/agricore/plant/AgriCondition.java
@@ -6,6 +6,7 @@ import com.agricraft.agricore.core.AgriCore;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  *
@@ -79,6 +80,15 @@ public class AgriCondition extends AgriStack {
 		} else {
 			return true;
 		}
+	}
+
+	/**
+	 * Attempts to create a stack of the desired class, wrapped in an Optional.
+	 * It uses `amount` from this instance for the stack size, instead of 1.
+	 */
+	@Override
+	public <T> Optional<T> toStack(Class<T> token) {
+		return this.toStack(token, amount);
 	}
 
 	@Override


### PR DESCRIPTION
The single parameter method is now overridden so that it returns a stack
with size equal to this amount field, instead of the default of 1.

----
### Notes:
* Fixes point number two in AgriCraft issue [#1054](https://github.com/AgriCraft/AgriCraft/issues/1054). 
* This fix works neatly, because the caller doesn't need to be changed. I also think matching the `amount` value is really the expected behavior for `toStack` anyhow.
* To be sure though, I searched for `AgriCondition#toStack(token)` being used somewhere else, and I didn't find it anywhere.
* The [alternative fix](https://github.com/CodesCubesAndCrashes/AgriCraft/commit/3d95171471d2e30f9d7233747434163713b6edc9) I tested is in AgriCraft, and it depends on a different [commit](https://github.com/CodesCubesAndCrashes/AgriCore/commit/fa6997bbe7d0474c265218e0ccba7c19dc380bec) here in AgriCore. It changes the call to be `toStack(token, amount)` to create the correctly sized stack. But to get the amount out of an AgriCondition requires that new accessor.

### Testing the fix: [The Album](http://imgur.com/a/EoUq8)

### The bottom line:
![2017-08-28_08 52 46](https://user-images.githubusercontent.com/28678248/29775494-575d170a-8bd3-11e7-93a7-f469d6b1801e.png)
